### PR TITLE
Add task completion state and finish action

### DIFF
--- a/ClipTimer/Localizable.xcstrings
+++ b/ClipTimer/Localizable.xcstrings
@@ -395,12 +395,32 @@
         }
       }
     },
+    "Finish" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminar"
+          }
+        }
+      }
+    },
     "Redo" : {
       "localizations" : {
         "es" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rehacer"
+          }
+        }
+      }
+    },
+    "Restart" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reiniciar"
           }
         }
       }

--- a/ClipTimer/Task.swift
+++ b/ClipTimer/Task.swift
@@ -11,19 +11,22 @@ struct Task: Identifiable, Codable {
     let id: UUID
     var name: String
     var elapsed: TimeInterval
+    var isCompleted: Bool = false
     
     // Custom initializer to generate UUID
-    init(name: String, elapsed: TimeInterval) {
+    init(name: String, elapsed: TimeInterval, isCompleted: Bool = false) {
         self.id = UUID()
         self.name = name
         self.elapsed = elapsed
+        self.isCompleted = isCompleted
     }
-    
+
     // Custom initializer with specific UUID (for preserving existing task IDs)
-    init(id: UUID, name: String, elapsed: TimeInterval) {
+    init(id: UUID, name: String, elapsed: TimeInterval, isCompleted: Bool = false) {
         self.id = id
         self.name = name
         self.elapsed = elapsed
+        self.isCompleted = isCompleted
     }
     
     // Calculate current elapsed time including active time if running

--- a/ClipTimer/TaskEditorWindow.swift
+++ b/ClipTimer/TaskEditorWindow.swift
@@ -127,7 +127,8 @@ private extension TaskEditorWindow {
     private func generateTasksText() -> String {
         return store.tasks.map { task in
             let currentElapsed = task.currentElapsed(activeTaskID: store.activeTaskID, startTime: store.activeTaskStartTime)
-            return "\(store.itemSymbol)\(task.name): \(currentElapsed.hms)"
+            let name = task.isCompleted ? "~~\(task.name)~~" : task.name
+            return "\(store.itemSymbol)\(name): \(currentElapsed.hms)"
         }.joined(separator: "\n")
     }
 

--- a/ClipTimer/TaskListView.swift
+++ b/ClipTimer/TaskListView.swift
@@ -16,7 +16,13 @@ struct TaskListView: View {
             ForEach(store.tasks) { task in
                 TaskRow(task: task) { store.toggle(task) }
                     .contextMenu {
-                        if !task.isCompleted {
+                        if task.isCompleted {
+                            Button {
+                                store.restart(task)
+                            } label: {
+                                Label("Restart", systemImage: "arrow.clockwise")
+                            }
+                        } else {
                             Button {
                                 store.finish(task)
                             } label: {

--- a/ClipTimer/TaskListView.swift
+++ b/ClipTimer/TaskListView.swift
@@ -16,6 +16,13 @@ struct TaskListView: View {
             ForEach(store.tasks) { task in
                 TaskRow(task: task) { store.toggle(task) }
                     .contextMenu {
+                        if !task.isCompleted {
+                            Button {
+                                store.finish(task)
+                            } label: {
+                                Label("Finish", systemImage: "checkmark")
+                            }
+                        }
                         Button(role: .destructive) {
                             store.delete(task)
                         } label: {

--- a/ClipTimer/TaskRow.swift
+++ b/ClipTimer/TaskRow.swift
@@ -25,6 +25,7 @@ struct TaskRow: View {
     var body: some View {
         HStack {
             Text(task.name)
+                .strikethrough(task.isCompleted)
             Spacer()
             Text(currentElapsed.hms)
                 .monospacedDigit()
@@ -49,7 +50,6 @@ struct TaskRow: View {
             }
         }
         .padding(.vertical, 4)
-        .strikethrough(task.isCompleted)
     }
 }
 

--- a/ClipTimer/TaskRow.swift
+++ b/ClipTimer/TaskRow.swift
@@ -28,25 +28,28 @@ struct TaskRow: View {
             Spacer()
             Text(currentElapsed.hms)
                 .monospacedDigit()
-            Button {
-                toggle()
-            } label: {
-                Image(systemName: isActive ? "power.circle.fill" : "power.circle")
-                    .resizable()
-                    .frame(width: 22, height: 22)
-                    .foregroundColor(isActive ? .green : .secondary)
-                    .scaleEffect(isAnimating ? 1.25 : 1.0)
-                    .animation(isActive
-                        ? .easeInOut(duration: 1).repeatForever(autoreverses: true)
-                        : .default,
-                        value: isAnimating)
-                    .padding(4)
+            if !task.isCompleted {
+                Button {
+                    toggle()
+                } label: {
+                    Image(systemName: isActive ? "power.circle.fill" : "power.circle")
+                        .resizable()
+                        .frame(width: 22, height: 22)
+                        .foregroundColor(isActive ? .green : .secondary)
+                        .scaleEffect(isAnimating ? 1.25 : 1.0)
+                        .animation(isActive
+                            ? .easeInOut(duration: 1).repeatForever(autoreverses: true)
+                            : .default,
+                            value: isAnimating)
+                        .padding(4)
+                }
+                .buttonStyle(.plain)
+                .onAppear { isAnimating = isActive }
+                .onChange(of: isActive) { _, newValue in isAnimating = newValue }
             }
-            .buttonStyle(.plain)
-            .onAppear { isAnimating = isActive }
-            .onChange(of: isActive) { _, newValue in isAnimating = newValue }
         }
         .padding(.vertical, 4)
+        .strikethrough(task.isCompleted)
     }
 }
 

--- a/ClipTimer/TaskRow.swift
+++ b/ClipTimer/TaskRow.swift
@@ -29,7 +29,13 @@ struct TaskRow: View {
             Spacer()
             Text(currentElapsed.hms)
                 .monospacedDigit()
-            if !task.isCompleted {
+            if task.isCompleted {
+                Image(systemName: "power.circle")
+                    .resizable()
+                    .frame(width: 22, height: 22)
+                    .padding(4)
+                    .hidden()
+            } else {
                 Button {
                     toggle()
                 } label: {

--- a/ClipTimer/TaskStore.swift
+++ b/ClipTimer/TaskStore.swift
@@ -140,6 +140,17 @@ final class TaskStore: ObservableObject {
             }
         }
     }
+
+    func restart(_ task: Task) {
+        pauseCurrentActiveTask()
+        mutateTasks(actionName: "Restart task") { tasks in
+            if let index = tasks.firstIndex(where: { $0.id == task.id }) {
+                tasks[index].isCompleted = false
+            }
+        }
+        activeTaskID = task.id
+        activeTaskStartTime = Date()
+    }
     
     func replaceTasksFromClipboard() {
         if let tasksString = NSPasteboard.general.string(forType: .string) {

--- a/ClipTimer/TaskStore.swift
+++ b/ClipTimer/TaskStore.swift
@@ -101,8 +101,9 @@ final class TaskStore: ObservableObject {
     // MARK: - Helper to build summary lines
     private func taskLines() -> [String] {
         tasks.map {
-            let line = "\(itemSymbol)\($0.name): \(getCurrentElapsed(for: $0).hms)"
-            return $0.isCompleted ? "~~\(line)~~" : line
+            let time = getCurrentElapsed(for: $0).hms
+            let name = $0.isCompleted ? "~~\($0.name)~~" : $0.name
+            return "\(itemSymbol)\(name): \(time)"
         }
     }
     

--- a/ClipTimerTests/TaskStoreFormattingTests.swift
+++ b/ClipTimerTests/TaskStoreFormattingTests.swift
@@ -84,13 +84,28 @@ final class TaskStoreFormattingTests: XCTestCase {
     
     func testTaskFormattingWithTabSymbols() {
         clearTasks()
-        
+
         taskStore.addTasks(from: tabSymbolTasksContent())
         
         let summaryText = taskStore.summaryText
         assertTasksInSummary([
             "•\tTab Task One: 0:00:00",
             "•\tTab Task Two: 0:00:00"
+        ], in: summaryText)
+    }
+
+    func testCompletedTasksAreStrikethrough() {
+        clearTasks()
+
+        taskStore.tasks = [
+            Task(name: "Done Task", elapsed: 30, isCompleted: true),
+            Task(name: "Open Task", elapsed: 45)
+        ]
+
+        let summaryText = taskStore.summaryText
+        assertTasksInSummary([
+            "~~Done Task: 0:00:30~~",
+            "Open Task: 0:00:45"
         ], in: summaryText)
     }
     

--- a/ClipTimerTests/TaskStoreFormattingTests.swift
+++ b/ClipTimerTests/TaskStoreFormattingTests.swift
@@ -104,7 +104,7 @@ final class TaskStoreFormattingTests: XCTestCase {
 
         let summaryText = taskStore.summaryText
         assertTasksInSummary([
-            "~~Done Task: 0:00:30~~",
+            "~~Done Task~~: 0:00:30",
             "Open Task: 0:00:45"
         ], in: summaryText)
     }

--- a/ClipTimerTests/TaskStoreFormattingTests.swift
+++ b/ClipTimerTests/TaskStoreFormattingTests.swift
@@ -108,6 +108,34 @@ final class TaskStoreFormattingTests: XCTestCase {
             "Open Task: 0:00:45"
         ], in: summaryText)
     }
+
+    func testFinishingTaskMovesItToEnd() {
+        clearTasks()
+
+        taskStore.tasks = [
+            Task(name: "First", elapsed: 0),
+            Task(name: "Second", elapsed: 0),
+            Task(name: "Third", elapsed: 0)
+        ]
+
+        let firstTask = taskStore.tasks[0]
+        taskStore.finish(firstTask)
+
+        XCTAssertEqual(taskStore.tasks.map { $0.name }, ["Second", "Third", "First"])
+        XCTAssertTrue(taskStore.tasks.last?.isCompleted ?? false)
+    }
+
+    func testReplaceTasksTogglesCompletionState() {
+        clearTasks()
+
+        taskStore.tasks = [Task(name: "Sample", elapsed: 0, isCompleted: true)]
+
+        taskStore.replaceTasks(from: "Sample: 0:00:00")
+        XCTAssertFalse(taskStore.tasks[0].isCompleted)
+
+        taskStore.replaceTasks(from: "~~Sample~~: 0:00:00")
+        XCTAssertTrue(taskStore.tasks[0].isCompleted)
+    }
     
     func testTaskFormattingPreservesSymbolsInTaskNames() {
         clearTasks()

--- a/ClipTimerTests/TaskStoreFormattingTests.swift
+++ b/ClipTimerTests/TaskStoreFormattingTests.swift
@@ -109,7 +109,7 @@ final class TaskStoreFormattingTests: XCTestCase {
         ], in: summaryText)
     }
 
-    func testFinishingTaskMovesItToEnd() {
+    func testFinishingTaskDoesNotChangeOrder() {
         clearTasks()
 
         taskStore.tasks = [
@@ -121,8 +121,8 @@ final class TaskStoreFormattingTests: XCTestCase {
         let firstTask = taskStore.tasks[0]
         taskStore.finish(firstTask)
 
-        XCTAssertEqual(taskStore.tasks.map { $0.name }, ["Second", "Third", "First"])
-        XCTAssertTrue(taskStore.tasks.last?.isCompleted ?? false)
+        XCTAssertEqual(taskStore.tasks.map { $0.name }, ["First", "Second", "Third"])
+        XCTAssertTrue(taskStore.tasks.first?.isCompleted ?? false)
     }
 
     func testReplaceTasksTogglesCompletionState() {

--- a/ClipTimerTests/TaskStoreFormattingTests.swift
+++ b/ClipTimerTests/TaskStoreFormattingTests.swift
@@ -136,6 +136,18 @@ final class TaskStoreFormattingTests: XCTestCase {
         taskStore.replaceTasks(from: "~~Sample~~: 0:00:00")
         XCTAssertTrue(taskStore.tasks[0].isCompleted)
     }
+
+    func testRestartTaskClearsCompletionAndActivates() {
+        clearTasks()
+
+        taskStore.tasks = [Task(name: "Task", elapsed: 0, isCompleted: true)]
+        let task = taskStore.tasks[0]
+
+        taskStore.restart(task)
+
+        XCTAssertFalse(taskStore.tasks[0].isCompleted)
+        XCTAssertEqual(taskStore.activeTaskID, task.id)
+    }
     
     func testTaskFormattingPreservesSymbolsInTaskNames() {
         clearTasks()


### PR DESCRIPTION
## Summary
- add `isCompleted` flag to `Task`
- allow finishing tasks via context menu and prevent re-starting finished tasks
- strikethrough completed tasks in UI and clipboard copy

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -project ClipTimer.xcodeproj -scheme ClipTimer -destination 'platform=macOS'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689adfe570a883229b3421a9219e2730