### PR TITLE
Add Command-F shortcut to finish active tasks

### DIFF
--- a/ClipTimer/ClipTimerApp.swift
+++ b/ClipTimer/ClipTimerApp.swift
@@ -153,6 +153,10 @@ struct ClipTimerApp: App {
                     store.restartLastPausedTask()
                 }
                 .keyboardShortcut("r")
+                Button("Finish active task") {
+                    store.finishActiveTask()
+                }
+                .keyboardShortcut("f")
             }
             
 

--- a/ClipTimer/HelpOverlay.swift
+++ b/ClipTimer/HelpOverlay.swift
@@ -60,6 +60,13 @@ struct HelpOverlay: View {
                 Text("Restart last paused task")
             }
             .padding(.leading, 12)
+            HStack {
+                Text("⌘F")
+                    .font(.system(.body, design: .monospaced).weight(.semibold))
+                Spacer(minLength: 16)
+                Text("Finish active task")
+            }
+            .padding(.leading, 12)
 
             Text("Export Tasks")
                 .font(.headline)

--- a/ClipTimer/HelpWindow.swift
+++ b/ClipTimer/HelpWindow.swift
@@ -47,7 +47,7 @@ struct HelpWindow: View {
                                   details: """
                                            Click the power icon next to a task to start \
                                            timing it. Only one task runs at a time. \
-                                           Press ⌘P to pause, ⌘R to restart the last paused task.
+                                           Press ⌘P to pause, ⌘R to restart the last paused task, ⌘F to finish.
                                            """)
                              
                              step(number: 4,

--- a/ClipTimer/Localizable.xcstrings
+++ b/ClipTimer/Localizable.xcstrings
@@ -71,6 +71,16 @@
         }
       }
     },
+    "⌘F" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⌘F"
+          }
+        }
+      }
+    },
     "⌘P" : {
       "localizations" : {
         "es" : {
@@ -132,12 +142,12 @@
         }
       }
     },
-    "Click the power icon next to a task to start timing it. Only one task runs at a time. Press ⌘P to pause, ⌘R to restart the last paused task." : {
+    "Click the power icon next to a task to start timing it. Only one task runs at a time. Press ⌘P to pause, ⌘R to restart the last paused task, ⌘F to finish." : {
       "localizations" : {
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Haz clic en el icono de encendido junto a una tarea para comenzar a cronometrarla. Solo una tarea se ejecuta a la vez. Presiona ⌘P para pausar, ⌘R para reiniciar la última tarea pausada."
+            "value" : "Haz clic en el icono de encendido junto a una tarea para comenzar a cronometrarla. Solo una tarea se ejecuta a la vez. Presiona ⌘P para pausar, ⌘R para reiniciar la última tarea pausada, ⌘F para terminar."
           }
         }
       }
@@ -431,6 +441,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reiniciar última tarea pausada"
+          }
+        }
+      }
+    },
+    "Finish active task" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminar tarea activa"
           }
         }
       }

--- a/ClipTimer/TaskStore.swift
+++ b/ClipTimer/TaskStore.swift
@@ -396,8 +396,8 @@ final class TaskStore: ObservableObject {
     
     func restartLastPausedTask() {
         guard let pausedID = lastPausedTaskID,
-              let _ = tasks.firstIndex(where: { $0.id == pausedID }) else { 
-            return 
+              let _ = tasks.firstIndex(where: { $0.id == pausedID }) else {
+            return
         }
         
         // First pause any currently active task
@@ -410,7 +410,12 @@ final class TaskStore: ObservableObject {
         // Clear the last paused ID to prevent re-triggering
         lastPausedTaskID = nil
     }
-    
+
+    func finishActiveTask() {
+        guard let task = activeTask else { return }
+        finish(task)
+    }
+
     /// Clear the last paused task ID without affecting the currently active task
     /// This is used when we want to "forget" about a previously paused task
     func clearLastPausedTask() {

--- a/ClipTimerTests/TaskStoreTimerTests.swift
+++ b/ClipTimerTests/TaskStoreTimerTests.swift
@@ -102,6 +102,17 @@ final class TaskStoreTimerTests: XCTestCase {
         XCTAssertEqual(taskStore.activeTaskID, task1.id)
         XCTAssertNotEqual(taskStore.activeTaskID, task2.id)
     }
+
+    func testFinishActiveTask() {
+        let task = Task(name: "Task", elapsed: 100)
+        taskStore.tasks = [task]
+
+        taskStore.toggle(task)
+        taskStore.finishActiveTask()
+
+        XCTAssertTrue(taskStore.tasks[0].isCompleted)
+        XCTAssertNil(taskStore.activeTaskID)
+    }
     
     func testTaskEditorPauseResumeWorkflow() {
         let task1 = Task(name: "Task 1", elapsed: 100)

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ ClipTimer automatically parses various time formats when pasting tasks:
 ### Keyboard Shortcuts
 - `⌘+V`: Paste tasks from clipboard
 - `⌘+C`: Copy task summary back to clipboard
+- `⌘+F`: Finish active task
 - `⌘+?`: Show help overlay
 - `⌘E`: Open Task Editor window
 - `⇧⌘⏎`: Add tasks from editor


### PR DESCRIPTION
## Summary
- add `finishActiveTask` handler to TaskStore
- expose Command-F menu item to finish the active task
- document shortcut in help views and README
- cover finish shortcut with unit test

## Testing
- `xcodebuild test -scheme ClipTimer -destination 'platform=macOS'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bbb3ad6ac8322b782ecc2699c792e