### PR TITLE
Document task completion instructions

### DIFF
--- a/ClipTimer/HelpWindow.swift
+++ b/ClipTimer/HelpWindow.swift
@@ -57,8 +57,17 @@ struct HelpWindow: View {
                                            (or press ⌘Z / ⇧⌘Z to undo/redo). \
                                            You can always paste a fresh list to replace all tasks.
                                            """)
-                             
+
                              step(number: 5,
+                                  title: "Finish completed tasks",
+                                  details: """
+                                           Right-click a task and choose `Finish` to mark it as \
+                                           completed. Finished tasks show a strikethrough and \
+                                           won't start unless you `Restart` them from the \
+                                           context menu.
+                                           """)
+
+                             step(number: 6,
                                   title: "Export your work",
                                   details: """
                                            Press ⌘C to copy a neatly formatted summary, \

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A clipboard-driven time tracking app for macOS that helps you monitor time spent
 - **Auto-Pause**: Automatically pauses active tasks when you quit the app
 - **Data Persistence**: Your tasks and elapsed times are automatically saved
 - **Task Editor Window**: Write or edit multiple tasks in a dedicated window (⌘E)
+- **Task Completion**: Mark tasks as finished and restart them later if needed
 
 ### 🔄 Smart Workflow
 - **Clipboard-First Design**: Paste task lists from any source (notes, emails, documents)
@@ -58,7 +59,8 @@ A clipboard-driven time tracking app for macOS that helps you monitor time spent
 1. **Add Tasks**: Paste task lists from your clipboard (supports time formats like "Task: 1:30:45")
 2. **Start Tracking**: Click the play button next to any task
 3. **Pause/Resume**: Click the pause button or start another task
-4. **Export Summary**: Copy all tasks with elapsed times back to clipboard
+4. **Finish Tasks**: Right-click a task and choose `Finish` to mark it completed (use `Restart` to resume)
+5. **Export Summary**: Copy all tasks with elapsed times back to clipboard
 
 ### Supported Clipboard Formats
 ClipTimer automatically parses various time formats when pasting tasks:


### PR DESCRIPTION
## Summary
- add task completion step in help window
- describe finishing tasks in features and usage sections of README

## Testing
- `xcodebuild test -scheme ClipTimer -destination 'platform=macOS'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bbb7e1e9883229075921872fad563