### PR TITLE
Fix localization testing and Info.plist

### DIFF
--- a/ClipTimer/Info.plist
+++ b/ClipTimer/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleLocalizations</key>
 	<array>
 		<string>en</string>
-		<string>Spanish (es)</string>
+		<string>es</string>
 	</array>
 </dict>
 </plist>

--- a/ClipTimerTests/TaskStoreUITests.swift
+++ b/ClipTimerTests/TaskStoreUITests.swift
@@ -47,27 +47,15 @@ final class TaskStoreUITests: XCTestCase {
     // MARK: - UI Text Tests
     
     func testEmptyTasksPlaceholderText() {
-        // Test that EmptyTasksPlaceholder shows the exact text from the AppStore version
-        // This prevents accidental changes to the user-facing instructions
-        
-        // The exact text that should appear in EmptyTasksPlaceholder
-        let expectedTitle = "No tasks yet"
-        let expectedInstructions = "Copy the list of tasks (with/without times)\n to the clipboard and paste them here."
-        
-        // Verify the strings exist in the localization file and return the expected Spanish text
-        XCTAssertEqual(NSLocalizedString("No tasks yet", comment: "Message shown when there are no tasks"), 
-                      "Aún no hay tareas", 
-                      "Title should be 'Aún no hay tareas' in Spanish")
-        
-        XCTAssertEqual(NSLocalizedString("Copy the list of tasks (with/without times)\n to the clipboard and paste them here.", comment: "Instructions for empty state"), 
-                      "Copia la lista de tareas (con/sin tiempos)\n al portapapeles y pégalas aquí.", 
-                      "Instructions should be properly translated to Spanish")
-        
-        // Also verify that TaskStore empty state shows the correct message
+        // Verify TaskStore uses whatever the current runtime localization resolves to
         clearTasks()
         let emptyMessage = taskStore.summaryText
-        XCTAssertEqual(emptyMessage, "Aún no hay tareas", 
-                      "TaskStore should show the same empty message as EmptyTasksPlaceholder")
+        let expectedRuntimeString = NSLocalizedString("No tasks yet", comment: "Message shown when there are no tasks")
+        XCTAssertEqual(
+            emptyMessage,
+            expectedRuntimeString,
+            "TaskStore should show the empty state message matching current runtime localization"
+        )
     }
     
     // MARK: - Test Helpers


### PR DESCRIPTION
Summary
- Fix Info.plist CFBundleLocalizations: use `es` instead of `Spanish (es)`.
- Stabilize tests: make empty-state UI test locale-independent (asserts runtime-localized string).
- Remove temporary Spanish-only localization test (per request).
- Revert scheme language forcing; tests no longer require Spanish scheme.

Why
- Tests were failing in non-Spanish environments because they asserted specific Spanish strings via NSLocalizedString without setting the app/test language.
- The Info.plist localization identifier was non-standard, which could interfere with language resolution.

Impact
- App logic unchanged; only test robustness and a plist metadata fix.
- Low risk: User-visible strings remain the same; tests are now environment-agnostic.

Validation
- Ran `xcodebuild` for the updated test and full suite locally; no failures reported in this environment.
- Verified Spanish strings exist in Localizable.xcstrings and are used by the app at runtime.

Follow-ups (optional)
- If desired, add a dedicated localization verification test that asserts exact Spanish strings but skips when `es.lproj` isn’t embedded in the test host.
